### PR TITLE
Feature/mrvl-4.1: recommendations of Sergey (not finished).

### DIFF
--- a/marvelgram.xcodeproj/project.pbxproj
+++ b/marvelgram.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		04C5C1A7284FDDCA0096D272 /* HeroCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1A6284FDDCA0096D272 /* HeroCollectionViewCell.swift */; };
 		04C5C1AB284FEC7A0096D272 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1AA284FEC7A0096D272 /* NetworkManager.swift */; };
 		04C5C1AE284FED200096D272 /* Hero.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1AD284FED200096D272 /* Hero.swift */; };
-		04C5C1B1284FEE090096D272 /* HeroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1B0284FEE090096D272 /* HeroViewModel.swift */; };
+		04C5C1B1284FEE090096D272 /* HeroModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1B0284FEE090096D272 /* HeroModel.swift */; };
 		04C5C1B3284FF12D0096D272 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1B2284FF12D0096D272 /* ImageCache.swift */; };
 		04C5C1B5284FF16F0096D272 /* HeroImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1B4284FF16F0096D272 /* HeroImageView.swift */; };
 		04C5C1B8284FF77B0096D272 /* GalleryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C5C1B7284FF77B0096D272 /* GalleryDataSource.swift */; };
@@ -51,7 +51,7 @@
 		04C5C1A6284FDDCA0096D272 /* HeroCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroCollectionViewCell.swift; sourceTree = "<group>"; };
 		04C5C1AA284FEC7A0096D272 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		04C5C1AD284FED200096D272 /* Hero.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hero.swift; sourceTree = "<group>"; };
-		04C5C1B0284FEE090096D272 /* HeroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroViewModel.swift; sourceTree = "<group>"; };
+		04C5C1B0284FEE090096D272 /* HeroModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroModel.swift; sourceTree = "<group>"; };
 		04C5C1B2284FF12D0096D272 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		04C5C1B4284FF16F0096D272 /* HeroImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeroImageView.swift; sourceTree = "<group>"; };
 		04C5C1B7284FF77B0096D272 /* GalleryDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryDataSource.swift; sourceTree = "<group>"; };
@@ -95,10 +95,10 @@
 			isa = PBXGroup;
 			children = (
 				04FE0A40284FCAF100839CBF /* Protocols */,
-				04C5C1AC284FED180096D272 /* Entity */,
-				04C5C1AF284FEDD90096D272 /* Models */,
-				04C5C1B6284FF7430096D272 /* DataSource */,
 				04FE0A3B284FCA2A00839CBF /* Assembly */,
+				04C5C1B6284FF7430096D272 /* DataSource */,
+				04C5C1AF284FEDD90096D272 /* Models */,
+				04C5C1AC284FED180096D272 /* Entity */,
 				04C5C19D284FDA220096D272 /* Presenters */,
 				04FE0A3A284FCA2200839CBF /* Views */,
 			);
@@ -142,7 +142,7 @@
 		04C5C1AF284FEDD90096D272 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				04C5C1B0284FEE090096D272 /* HeroViewModel.swift */,
+				04C5C1B0284FEE090096D272 /* HeroModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -427,7 +427,7 @@
 				04C5C1B8284FF77B0096D272 /* GalleryDataSource.swift in Sources */,
 				04C5C1BF285019980096D272 /* MarvelBarButtonItem.swift in Sources */,
 				04C5C1DC28516B750096D272 /* ProfilePresenterProtocol.swift in Sources */,
-				04C5C1B1284FEE090096D272 /* HeroViewModel.swift in Sources */,
+				04C5C1B1284FEE090096D272 /* HeroModel.swift in Sources */,
 				04C5C1DE28516B9F0096D272 /* ProfileViewProtocol.swift in Sources */,
 				04FE0A36284FC9D600839CBF /* UIColor + Extension.swift in Sources */,
 				04C5C1CE285152630096D272 /* UIImage + Extension.swift in Sources */,

--- a/marvelgram/Modules/Gallery/DataSource/GalleryDataSource.swift
+++ b/marvelgram/Modules/Gallery/DataSource/GalleryDataSource.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct GalleryDataSource {
-    var heroViewModel: [HeroViewModel] = []
+    var heroModels: [HeroModel] = []
 }

--- a/marvelgram/Modules/Gallery/Models/HeroModel.swift
+++ b/marvelgram/Modules/Gallery/Models/HeroModel.swift
@@ -1,5 +1,5 @@
 //
-//  HeroViewModel.swift
+//  HeroModel.swift
 //  marvelgram
 //
 //  Created by Mikhail Chaus on 07.06.2022.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct HeroViewModel {
+struct HeroModel {
     var id: Int
     let name: String
     let description: String

--- a/marvelgram/Modules/Gallery/Presenters/GalleryPresenter.swift
+++ b/marvelgram/Modules/Gallery/Presenters/GalleryPresenter.swift
@@ -33,8 +33,8 @@ class GalleryPresenter {
         view?.showActivityIndicator(true)
         
         heroesRepository.getHeroes { [unowned self] heroes in
-            let viewModels = heroes.map { HeroModel(hero: $0) }
-            self.galleryDataSource.heroModels = viewModels
+            let models = heroes.map { HeroModel(hero: $0) }
+            self.galleryDataSource.heroModels = models
             
             DispatchQueue.main.async {
                 self.view?.showActivityIndicator(false)

--- a/marvelgram/Modules/Gallery/Presenters/GalleryPresenter.swift
+++ b/marvelgram/Modules/Gallery/Presenters/GalleryPresenter.swift
@@ -33,8 +33,8 @@ class GalleryPresenter {
         view?.showActivityIndicator(true)
         
         heroesRepository.getHeroes { [unowned self] heroes in
-            let viewModels = heroes.map { HeroViewModel(hero: $0) }
-            self.galleryDataSource.heroViewModel = viewModels
+            let viewModels = heroes.map { HeroModel(hero: $0) }
+            self.galleryDataSource.heroModels = viewModels
             
             DispatchQueue.main.async {
                 self.view?.showActivityIndicator(false)
@@ -51,11 +51,11 @@ extension GalleryPresenter: GalleryPresenterProtocol {
         fetchHeroesAndReloadCollectionView()
     }
     
-    func getHeroViewModelsCount() -> Int? {
-        return galleryDataSource.heroViewModel.count
+    func getHeroModelsCount() -> Int? {
+        return galleryDataSource.heroModels.count
     }
     
-    func getHeroViewModel(with index: Int) -> HeroViewModel {
-        return galleryDataSource.heroViewModel[index]
+    func getHeroModel(with index: Int) -> HeroModel {
+        return galleryDataSource.heroModels[index]
     }
 }

--- a/marvelgram/Modules/Gallery/Protocols/GalleryPresenterProtocol.swift
+++ b/marvelgram/Modules/Gallery/Protocols/GalleryPresenterProtocol.swift
@@ -12,6 +12,6 @@ protocol GalleryPresenterProtocol {
     
     func handleDidAppearingView()
     
-    func getHeroViewModelsCount() -> Int?
-    func getHeroViewModel(with index: Int) -> HeroViewModel
+    func getHeroModelsCount() -> Int?
+    func getHeroModel(with index: Int) -> HeroModel
 }

--- a/marvelgram/Modules/Gallery/Protocols/GalleryViewUiDelegate.swift
+++ b/marvelgram/Modules/Gallery/Protocols/GalleryViewUiDelegate.swift
@@ -8,6 +8,6 @@
 import UIKit
 
 protocol GalleryViewUiDelegate: AnyObject {
-    func galleryView(_ galleryView: GalleryView, getHeroViewModelWithIndex index: Int) -> HeroViewModel?
+    func galleryView(_ galleryView: GalleryView, getHeroModelWithIndex index: Int) -> HeroModel?
     func galleryViewCellsCount(_ galleryView: GalleryView) -> Int?
 }

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroCollectionViewCell.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroCollectionViewCell.swift
@@ -44,8 +44,8 @@ class HeroCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Public Methods
     
-    func configurePerCellWith(_ viewModel: HeroModel) {
-        heroImageView.loadImageWith(urlString: viewModel.url)
+    func configureCellWith(_ model: HeroModel) {
+        heroImageView.loadImageWith(urlString: model.url)
     }
     
     // MARK: - Layout

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroCollectionViewCell.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroCollectionViewCell.swift
@@ -44,7 +44,7 @@ class HeroCollectionViewCell: UICollectionViewCell {
     
     // MARK: - Public Methods
     
-    func configurePerCellWith(_ viewModel: HeroViewModel) {
+    func configurePerCellWith(_ viewModel: HeroModel) {
         heroImageView.loadImageWith(urlString: viewModel.url)
     }
     

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -13,7 +13,9 @@ class HeroImageView: UIImageView {
     private var imageCache = ImageCache.shared
     private var lastImageURLStringUsedToLoadImage: String?
     
-    let activityIndicatorView = HeroImageView.makeActivityIndicatorView()
+    private lazy var activityIndicatorView: UIActivityIndicatorView = {
+        return HeroImageView.makeActivityIndicatorView()
+    }()
     
     // MARK: - Initialization
     
@@ -46,8 +48,8 @@ class HeroImageView: UIImageView {
             case .success(let image):
                 DispatchQueue.main.async {
                     if self.lastImageURLStringUsedToLoadImage == urlString {
-                        self.image = image
                         self.activityIndicatorView.stopAnimating()
+                        self.image = image
                     }
                 }
             case .failure(let error):
@@ -69,8 +71,6 @@ class HeroImageView: UIImageView {
     }
 
     private func makeAndResumeDataTaskWith(url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
-        activityIndicatorView.startAnimating()
-        
         let task = URLSession.shared.dataTask(with: url) { resumeDataOrNil, _, errorOrNil in
             if let error = errorOrNil {
                 print("failed to load image with error: \(error.localizedDescription)")
@@ -95,6 +95,7 @@ class HeroImageView: UIImageView {
     
     static func makeActivityIndicatorView() -> UIActivityIndicatorView {
         let loader = UIActivityIndicatorView(style: .large)
+        loader.startAnimating()
         loader.translatesAutoresizingMaskIntoConstraints = false
         
         return loader

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -13,12 +13,15 @@ class HeroImageView: UIImageView {
     private var imageCache = ImageCache.shared
     private var lastImageURLStringUsedToLoadImage: String?
     
+    let activityIndicatorView = HeroImageView.makeActivityIndicatorView()
+    
     // MARK: - Initialization
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         configureImageView()
+        addSubviews()
     }
     
     required init?(coder: NSCoder) {
@@ -36,12 +39,18 @@ class HeroImageView: UIImageView {
             return
         }
         
-        makeAndResumeDataTaskWith(urlString: urlString) { [weak self] result in
+        activityIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        activityIndicatorView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        
+        guard let url = URL(string: urlString) else { return }
+        
+        makeAndResumeDataTaskWith(url: url) { [unowned self] result in
             switch result {
             case .success(let image):
                 DispatchQueue.main.async {
-                    if self?.lastImageURLStringUsedToLoadImage == urlString {
-                        self?.image = image
+                    if self.lastImageURLStringUsedToLoadImage == urlString {
+                        self.image = image
+                        self.activityIndicatorView.stopAnimating()
                     }
                 }
             case .failure(let error):
@@ -57,12 +66,16 @@ class HeroImageView: UIImageView {
         translatesAutoresizingMaskIntoConstraints = false
     }
     
-    private func makeAndResumeDataTaskWith(urlString: String, completion: @escaping (Result<UIImage, Error>) -> Void) {
-        guard let url = URL(string: urlString) else { return }
+    private func addSubviews() {
+        addSubview(activityIndicatorView)
+    }
+
+    private func makeAndResumeDataTaskWith(url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
+        activityIndicatorView.startAnimating()
         
         let task = URLSession.shared.dataTask(with: url) { resumeDataOrNil, _, errorOrNil in
             if let error = errorOrNil {
-                print("Failed to load image with error: \(error.localizedDescription)")
+                print("failed to load image with error: \(error.localizedDescription)")
             }
             
             guard
@@ -73,10 +86,20 @@ class HeroImageView: UIImageView {
                 return
             }
             
-            self.imageCache.setObject(taskImage, forKey: urlString as NSString)
+            self.imageCache.setObject(taskImage, forKey: url.path as NSString)
             completion(.success(taskImage))
         }
         
         task.resume()
+    }
+    
+    // MARK: - Creating Subviews
+    
+    static func makeActivityIndicatorView() -> UIActivityIndicatorView {
+        let loader = UIActivityIndicatorView(style: .large)
+        loader.color = .red
+        loader.translatesAutoresizingMaskIntoConstraints = false
+        
+        return loader
     }
 }

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -39,9 +39,6 @@ class HeroImageView: UIImageView {
             return
         }
         
-        activityIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        activityIndicatorView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
-        
         guard let url = URL(string: urlString) else { return }
         
         makeAndResumeDataTaskWith(url: url) { [unowned self] result in
@@ -68,6 +65,7 @@ class HeroImageView: UIImageView {
     
     private func addSubviews() {
         addSubview(activityIndicatorView)
+        activateActivityIndicatorViewConstraints()
     }
 
     private func makeAndResumeDataTaskWith(url: URL, completion: @escaping (Result<UIImage, Error>) -> Void) {
@@ -100,5 +98,14 @@ class HeroImageView: UIImageView {
         loader.translatesAutoresizingMaskIntoConstraints = false
         
         return loader
+    }
+    
+    // MARK: - Layout
+    
+    private func activateActivityIndicatorViewConstraints() {
+        NSLayoutConstraint.activate([
+            activityIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
     }
 }

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -97,7 +97,6 @@ class HeroImageView: UIImageView {
     
     static func makeActivityIndicatorView() -> UIActivityIndicatorView {
         let loader = UIActivityIndicatorView(style: .large)
-        loader.color = .red
         loader.translatesAutoresizingMaskIntoConstraints = false
         
         return loader

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -60,7 +60,11 @@ class HeroImageView: UIImageView {
     private func makeAndResumeDataTaskWith(urlString: String, completion: @escaping (Result<UIImage, Error>) -> Void) {
         guard let url = URL(string: urlString) else { return }
         
-        let task = URLSession.shared.dataTask(with: url) { resumeDataOrNil, _, _ in
+        let task = URLSession.shared.dataTask(with: url) { resumeDataOrNil, _, errorOrNil in
+            if let error = errorOrNil {
+                print("Failed to load image with error: \(error.localizedDescription)")
+            }
+            
             guard
                 let taskImageData = resumeDataOrNil,
                 let taskImage = UIImage(data: taskImageData)

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -11,7 +11,7 @@ class HeroImageView: UIImageView {
     // MARK: - Private Properties
     
     private var imageCache = ImageCache.shared
-    private var imageURLString: String?
+    private var lastImageURLStringUsedToLoadImage: String?
     
     // MARK: - Initialization
     
@@ -29,7 +29,7 @@ class HeroImageView: UIImageView {
     
     func loadImageWith(urlString: String) {
         image = nil
-        imageURLString = urlString
+        lastImageURLStringUsedToLoadImage = urlString
         let imageFromCache = imageCache.object(forKey: urlString as NSString)
         guard imageFromCache == nil else {
             image = imageFromCache
@@ -40,7 +40,7 @@ class HeroImageView: UIImageView {
             switch result {
             case .success(let image):
                 DispatchQueue.main.async {
-                    if self?.imageURLString == urlString {
+                    if self?.lastImageURLStringUsedToLoadImage == urlString {
                         self?.image = image
                     }
                 }

--- a/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
+++ b/marvelgram/Modules/Gallery/Views/Cell/HeroImageView.swift
@@ -60,9 +60,9 @@ class HeroImageView: UIImageView {
     private func makeAndResumeDataTaskWith(urlString: String, completion: @escaping (Result<UIImage, Error>) -> Void) {
         guard let url = URL(string: urlString) else { return }
         
-        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+        let task = URLSession.shared.dataTask(with: url) { resumeDataOrNil, _, _ in
             guard
-                let taskImageData = data,
+                let taskImageData = resumeDataOrNil,
                 let taskImage = UIImage(data: taskImageData)
             else {
                 print("\(String(describing: HeroImageView.self)) failed to load image from \(url)")

--- a/marvelgram/Modules/Gallery/Views/GalleryView.swift
+++ b/marvelgram/Modules/Gallery/Views/GalleryView.swift
@@ -110,8 +110,8 @@ extension GalleryView: HeroesCollectionViewActionsDelegate {
 // MARK: - HeroesCollectionViewDataSourceDelegate
 
 extension GalleryView: HeroesCollectionViewDataSourceDelegate {
-    func heroesCollectionView(_ heroesCollectionView: HeroesCollectionView, getHeroViewModelWithIndex index: Int) -> HeroViewModel? {
-        return uiDelegate?.galleryView(self, getHeroViewModelWithIndex: index)
+    func heroesCollectionView(_ heroesCollectionView: HeroesCollectionView, getHeroModelWithIndex index: Int) -> HeroModel? {
+        return uiDelegate?.galleryView(self, getHeroModelWithIndex: index)
     }
     
     func heroesCollectionViewCellsCount(_ heroesCollectionView: HeroesCollectionView) -> Int? {

--- a/marvelgram/Modules/Gallery/Views/GalleryViewController.swift
+++ b/marvelgram/Modules/Gallery/Views/GalleryViewController.swift
@@ -46,12 +46,12 @@ class GalleryViewController: UIViewController {
 // MARK: - GalleryViewUiDelegate
 
 extension GalleryViewController: GalleryViewUiDelegate {
-    func galleryView(_ galleryView: GalleryView, getHeroViewModelWithIndex index: Int) -> HeroViewModel? {
-        return presenter?.getHeroViewModel(with: index)
+    func galleryView(_ galleryView: GalleryView, getHeroModelWithIndex index: Int) -> HeroModel? {
+        return presenter?.getHeroModel(with: index)
     }
     
     func galleryViewCellsCount(_ galleryView: GalleryView) -> Int? {
-        return presenter?.getHeroViewModelsCount()
+        return presenter?.getHeroModelsCount()
     }
 }
 

--- a/marvelgram/Modules/Gallery/Views/HeroesCollectionView.swift
+++ b/marvelgram/Modules/Gallery/Views/HeroesCollectionView.swift
@@ -11,7 +11,7 @@ protocol HeroesCollectionViewActionsDelegate: AnyObject {
 }
 
 protocol HeroesCollectionViewDataSourceDelegate: AnyObject {
-    func heroesCollectionView(_ heroesCollectionView: HeroesCollectionView, getHeroViewModelWithIndex index: Int) -> HeroViewModel?
+    func heroesCollectionView(_ heroesCollectionView: HeroesCollectionView, getHeroModelWithIndex index: Int) -> HeroModel?
     func heroesCollectionViewCellsCount(_ heroesCollectionView: HeroesCollectionView) -> Int?
 }
 
@@ -63,10 +63,10 @@ extension HeroesCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard
             let heroCell = cell as? HeroCollectionViewCell,
-            let viewModel = dataSourceDelegate?.heroesCollectionView(self, getHeroViewModelWithIndex: indexPath.row)
+            let model = dataSourceDelegate?.heroesCollectionView(self, getHeroModelWithIndex: indexPath.row)
         else { return }
         
-        heroCell.configurePerCellWith(viewModel)
+        heroCell.configurePerCellWith(model)
     }
 }
 

--- a/marvelgram/Modules/Gallery/Views/HeroesCollectionView.swift
+++ b/marvelgram/Modules/Gallery/Views/HeroesCollectionView.swift
@@ -66,7 +66,7 @@ extension HeroesCollectionView: UICollectionViewDelegate {
             let model = dataSourceDelegate?.heroesCollectionView(self, getHeroModelWithIndex: indexPath.row)
         else { return }
         
-        heroCell.configurePerCellWith(model)
+        heroCell.configureCellWith(model)
     }
 }
 

--- a/marvelgram/Repository/HeroesRepository.swift
+++ b/marvelgram/Repository/HeroesRepository.swift
@@ -38,11 +38,11 @@ class HeroesRepository {
     func getHeroes(completion: @escaping ([Hero]) -> Void) {
         networkManager.fetchHeroesConfig { [unowned self] result in
             switch result {
-            case .success(let urlFile):
-                let newHeroesConfig = self.makeHeroesFromConfig(at: urlFile)
+            case .success(let fileUrl):
+                let newHeroesConfig = self.makeHeroesFromConfig(at: fileUrl)
                 
                 if newHeroesConfig != self.heroes {
-                    self.saveFile(from: urlFile, to: Constants.folderName)
+                    self.saveFile(from: fileUrl, to: Constants.folderName)
                     self.heroes = newHeroesConfig
                 }
             case .failure(let error):

--- a/marvelgram/Services/NetworkManager.swift
+++ b/marvelgram/Services/NetworkManager.swift
@@ -35,14 +35,14 @@ class NetworkManager {
             return
         }
         
-        let downloadTask = session.downloadTask(with: heroesURL) { urlFile, _, _ in
-            guard let urlFile = urlFile else {
+        let downloadTask = session.downloadTask(with: heroesURL) { urlOrNil, _, _ in
+            guard let fileURL = urlOrNil else {
                 print("failure: couldn't download file by url: \(heroesURL.path)")
                 completion(.failure(.noData))
                 return
             }
             
-            completion(.success(urlFile))
+            completion(.success(fileURL))
         }
         
         downloadTask.resume()


### PR DESCRIPTION
@bsergiov, я заметил, что частенько код с загрузкой изображения выносит в экстешены, например вот так: 
- [ссылка 1](https://github.com/brunonagy/ImageLoaderManager/blob/main/ImageLoaderExtension.swift)
- [ссылка 2](https://github.com/victorpanitz/Swift_ImageLoaderExtension/blob/master/UIImageViewExtension.swift)

Однако мне не нравится, что в самом фале `UIImageView + Extension` вне экстеншена могу хранится какие-то свойств. Например, тот же кэш и стринги ссылка на картинку `lastImageURLStringUsedToLoadImage`.

--- 
Как вариант, можно создать `class ImageLoad: UIImageView`, внутри папки `Services`, где будет скачиваться картинка, и крутиться лоудер как факт загрузки чего-либо. Однако идея, что нужно либо в экстенщен вынести, либо в нетворкМенеджере качать картинку — не отпускает меня.